### PR TITLE
respect terminal size when printing

### DIFF
--- a/fancy_collections/formatting.py
+++ b/fancy_collections/formatting.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import shutil
 from typing import Tuple, List, Iterable, Any
 
+import shutil
 import pandas as pd
 
 
@@ -44,11 +45,6 @@ class Formatter:
         return str(key)
 
     def to_string(self) -> str:
-
-        def _calc_linelength(widths, columns):
-            # +3 to take the potential placholder into account and its sperator into account
-            return sum(widths[c] for c in columns) + len(self.column_seperator) * len(columns) + 3
-
         if len(self._obj) == 0:
             return self._stringify_empty_class(self._obj)
 
@@ -60,23 +56,19 @@ class Formatter:
             objects[key] = lines
             widths[key] = self._get_maxlen(lines + [key])
 
-        display_width = shutil.get_terminal_size().columns
+        # take the potential placeholder into acount
+        display_width = int(shutil.get_terminal_size().columns) - 3 - len(self.column_seperator)
 
         keys = tuple(widths.keys())
         front_keys, back_keys = set(), set()
-
+        line_length = 0
         for fkey, bkey in zip(keys, keys[::-1]):
-            line_length = _calc_linelength(widths, front_keys | back_keys | {fkey,})
+            line_length += widths[fkey] + len(self.column_seperator)
             if line_length < display_width:
                 front_keys.add(fkey)
-            else:
-                break
-
-            line_length = _calc_linelength(widths, front_keys | back_keys | {bkey,})
+            line_length += widths[bkey] + len(self.column_seperator)
             if line_length < display_width:
                 back_keys.add(bkey)
-            else:
-                break
 
         for k, v in objects.items():
             if k in front_keys:

--- a/fancy_collections/formatting.py
+++ b/fancy_collections/formatting.py
@@ -74,7 +74,7 @@ class Formatter:
             if k in front_keys:
                 self._add(k, v)
 
-        if not front_keys.intersection(back_keys) and front_keys.union(back_keys) != set(keys):
+        if len(front_keys) + len(back_keys) < len(keys):
             self._add("...", ["..."])
 
         for k, v in objects.items():

--- a/fancy_collections/formatting.py
+++ b/fancy_collections/formatting.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import shutil
 from typing import Tuple, List, Iterable, Any
 
-from matplotlib import shutil
+import shutil
 import pandas as pd
 
 

--- a/fancy_collections/formatting.py
+++ b/fancy_collections/formatting.py
@@ -125,7 +125,6 @@ class Formatter:
         return idx.to_string(**self._trunc_options, header=False)
 
     def _render(self) -> str:
-        # self.__reduce_to_display_width()
         string = self.__make_header()
         string += self.__make_seperator_row()
         while True:

--- a/fancy_collections/formatting.py
+++ b/fancy_collections/formatting.py
@@ -44,6 +44,11 @@ class Formatter:
         return str(key)
 
     def to_string(self) -> str:
+
+        def _calc_linelength(widths, columns):
+            # +3 to take the potential placholder into account and its sperator into account
+            return sum(widths[c] for c in columns) + len(self.column_seperator) * len(columns) + 3
+
         if len(self._obj) == 0:
             return self._stringify_empty_class(self._obj)
 
@@ -55,18 +60,23 @@ class Formatter:
             objects[key] = lines
             widths[key] = self._get_maxlen(lines + [key])
 
-        display_width = int(shutil.get_terminal_size().columns * 0.8)
+        display_width = shutil.get_terminal_size().columns
 
         keys = tuple(widths.keys())
         front_keys, back_keys = set(), set()
-        line_length = 0
+
         for fkey, bkey in zip(keys, keys[::-1]):
-            line_length += widths[fkey]
+            line_length = _calc_linelength(widths, front_keys | back_keys | {fkey,})
             if line_length < display_width:
                 front_keys.add(fkey)
-            line_length += widths[bkey]
+            else:
+                break
+
+            line_length = _calc_linelength(widths, front_keys | back_keys | {bkey,})
             if line_length < display_width:
                 back_keys.add(bkey)
+            else:
+                break
 
         for k, v in objects.items():
             if k in front_keys:

--- a/fancy_collections/formatting.py
+++ b/fancy_collections/formatting.py
@@ -73,7 +73,7 @@ class Formatter:
             if k in front_keys:
                 self._add(k, v)
 
-        if not front_keys.intersection(back_keys):
+        if not front_keys.intersection(back_keys) and front_keys.union(back_keys) != set(keys):
             self._add("...", ["..."])
 
         for k, v in objects.items():

--- a/fancy_collections/formatting.py
+++ b/fancy_collections/formatting.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import shutil
 from typing import Tuple, List, Iterable, Any
 
-import shutil
 import pandas as pd
 
 


### PR DESCRIPTION
Currently the printing method introduces line brakes if a `DictOfSeries` is getting to wide. With this MR the terminal width is respected and center columns are omitted like they are in pandas. Example output:

```shell
             0 |              1 |              2 | ... |             59 |             60 | 
============== | ============== | ============== | === | ============== | ============== | 
2020-01-01  -2 | 2020-01-01  -2 | 2020-01-01  -2 | ... | 2020-01-01  -2 | 2020-01-01  -2 | 
2020-01-02  -1 | 2020-01-02  -1 | 2020-01-02  -1 |     | 2020-01-02  -1 | 2020-01-02  -1 | 
2020-01-03   0 | 2020-01-03   0 | 2020-01-03   0 |     | 2020-01-03   0 | 2020-01-03   0 | 
2020-01-04   1 | 2020-01-04   1 | 2020-01-04   1 |     | 2020-01-04   1 | 2020-01-04   1 | 
2020-01-05   2 | 2020-01-05   2 | 2020-01-05   2 |     | 2020-01-05   2 | 2020-01-05   2 | 
2020-01-06   3 | 2020-01-06   3 | 2020-01-06   3 |     | 2020-01-06   3 | 2020-01-06   3 | 
2020-01-07   4 | 2020-01-07   4 | 2020-01-07   4 |     | 2020-01-07   4 | 2020-01-07   4 | 
2020-01-08   5 | 2020-01-08   5 | 2020-01-08   5 |     | 2020-01-08   5 | 2020-01-08   5 | 
2020-01-09   6 | 2020-01-09   6 | 2020-01-09   6 |     | 2020-01-09   6 | 2020-01-09   6 | 
2020-01-10   7 | 2020-01-10   7 | 2020-01-10   7 |     | 2020-01-10   7 | 2020-01-10   7 | 
2020-01-11   8 | 2020-01-11   8 | 2020-01-11   8 |     | 2020-01-11   8 | 2020-01-11   8 | 
2020-01-12   9 | 2020-01-12   9 | 2020-01-12   9 |     | 2020-01-12   9 | 2020-01-12   9 | 
2020-01-13  10 | 2020-01-13  10 | 2020-01-13  10 |     | 2020-01-13  10 | 2020-01-13  10 | 
2020-01-14  11 | 2020-01-14  11 | 2020-01-14  11 |     | 2020-01-14  11 | 2020-01-14  11 | 
2020-01-15  12 | 2020-01-15  12 | 2020-01-15  12 |     | 2020-01-15  12 | 2020-01-15  12 | 
```