### PR TITLE
fix missing docstring import

### DIFF
--- a/fancy_collections/core.py
+++ b/fancy_collections/core.py
@@ -158,6 +158,7 @@ class DictOfPandas(TypedSliceDict, IndexMixin):
 
         Examples
         --------
+        >>> from fancy_collections import DictOfPandas
         >>> frame = DictOfPandas(key0=pd.DataFrame({'c0': [1, 1], "c1": [2, 2]}))
         >>> frame   # doctest: +NORMALIZE_WHITESPACE
              key0 |


### PR DESCRIPTION
For whatever reason I accidentally removed an import in the `DictOfPandas.flatten` docstring, which makes the SaQC pipeline fail. 